### PR TITLE
Fix CMake building process on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - export CXX="g++-6" CC="gcc-6"
   # Build Boost.
   - wget https://raw.githubusercontent.com/WrinklyNinja/ci-scripts/1.5.0/install_boost.py
-  - python install_boost.py --directory ~ --boost-version 1.65.1 -a 64 -t gcc-6 filesystem locale system
+  - python install_boost.py --directory ~ --boost-version 1.65.1 -a 64 -t gcc-6 filesystem locale system thread
   # Install packages for generating documentation
   - pip install --user -r docs/requirements.txt
   # Add sphinx-build to PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
     packages:
       - libbz2-dev
       - libssl-dev
+      - libhttp-parser-dev
+      - libssh2-1-dev
       - gcc-6
       - g++-6
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ ELSE ()
     set(RUST_TARGET x86_64-unknown-linux-gnu)
 ENDIF ()
 
-find_package(Boost REQUIRED COMPONENTS locale filesystem system)
+find_package(Boost REQUIRED COMPONENTS locale filesystem system thread)
 
 ExternalProject_Add(GTest
                     PREFIX "external"
@@ -312,7 +312,11 @@ IF (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
                    z
                    crypto
                    rt
-                   pthread)
+                   pthread
+                   icuuc
+                   icui18n
+                   ssh2
+                   http_parser)
 
     IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set (LOOT_LIBS ${LOOT_LIBS} supc++)


### PR DESCRIPTION
See issue #8. Fixed by adding `boost_thread`, `icuuc`, `icui18n`, `ssh2`
and `http_parser` to libs.

Using Arch Linux x86_64. My system is quite barebones, I can provide a
bit more detail about my build environment if it'd help.

I'm confused with Boost. I was getting lots of `boost::detail` errors, but that's an internal module used by parts of Boost. I figured to try `boost_thread` because `pthread` was required, and it worked.